### PR TITLE
Update to latest go-basher api

### DIFF
--- a/bindata.go
+++ b/bindata.go
@@ -76,7 +76,7 @@ func bashenv_bash_bash() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "bashenv/bash.bash", size: 557, mode: os.FileMode(420), modTime: time.Unix(1419752010, 0)}
+	info := bindata_file_info{name: "bashenv/bash.bash", size: 557, mode: os.FileMode(420), modTime: time.Unix(1425787452, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -96,7 +96,7 @@ func bashenv_cmd_bash() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "bashenv/cmd.bash", size: 1479, mode: os.FileMode(420), modTime: time.Unix(1414685718, 0)}
+	info := bindata_file_info{name: "bashenv/cmd.bash", size: 1479, mode: os.FileMode(420), modTime: time.Unix(1425787452, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -116,7 +116,7 @@ func bashenv_fn_bash() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "bashenv/fn.bash", size: 547, mode: os.FileMode(420), modTime: time.Unix(1414685718, 0)}
+	info := bindata_file_info{name: "bashenv/fn.bash", size: 547, mode: os.FileMode(420), modTime: time.Unix(1425787452, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -136,7 +136,7 @@ func bashenv_plugn_bash() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "bashenv/plugn.bash", size: 2774, mode: os.FileMode(420), modTime: time.Unix(1420233510, 0)}
+	info := bindata_file_info{name: "bashenv/plugn.bash", size: 2774, mode: os.FileMode(420), modTime: time.Unix(1425787452, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }

--- a/gateway.go
+++ b/gateway.go
@@ -96,10 +96,10 @@ func startGateway(wg *sync.WaitGroup, plugins *coproc.Host) *duplex.Peer {
 	return gateway
 }
 
-func TriggerGateway(args []string) int {
+func TriggerGateway(args []string) {
 	gatewaySock := PluginPath + "/gateway.sock"
 	if _, err := os.Stat(gatewaySock); os.IsNotExist(err) {
-		return 0
+		return
 	}
 	trigger := duplex.NewPeer()
 	defer trigger.Shutdown()
@@ -114,13 +114,12 @@ func TriggerGateway(args []string) int {
 	}
 	io.Copy(os.Stdout, ch)
 	ch.Close()
-	return 0
 }
 
-func ReloadGateway(args []string) int {
+func ReloadGateway(args []string) {
 	gatewaySock := PluginPath + "/gateway.sock"
 	if _, err := os.Stat(gatewaySock); os.IsNotExist(err) {
-		return 0
+		return
 	}
 	trigger := duplex.NewPeer()
 	defer trigger.Shutdown()
@@ -133,5 +132,4 @@ func ReloadGateway(args []string) int {
 	if err != nil {
 		panic(err)
 	}
-	return 0
 }

--- a/plugn.go
+++ b/plugn.go
@@ -21,17 +21,16 @@ func assert(err error) {
 	}
 }
 
-func TomlGet(args []string) int {
+func TomlGet(args []string) {
 	bytes, err := ioutil.ReadAll(os.Stdin)
 	assert(err)
 	var t map[string]interface{}
 	_, err = toml.Decode(string(bytes), &t)
 	assert(err)
 	fmt.Println(t[args[0]].(map[string]interface{})[args[1]])
-	return 0
 }
 
-func TomlExport(args []string) int {
+func TomlExport(args []string) {
 	plugin := args[0]
 	bytes, err := ioutil.ReadAll(os.Stdin)
 	assert(err)
@@ -51,10 +50,9 @@ func TomlExport(args []string) int {
 		k := strings.ToUpper(strings.Replace(key, "-", "_", -1))
 		fmt.Println("export CONFIG_" + k + "=\"${" + prefix + "_" + k + ":-\"" + config[key] + "\"}\"")
 	}
-	return 0
 }
 
-func TomlSet(args []string) int {
+func TomlSet(args []string) {
 	bytes, err := ioutil.ReadAll(os.Stdin)
 	assert(err)
 	var t map[string]map[string]string
@@ -68,7 +66,6 @@ func TomlSet(args []string) int {
 	assert(err)
 	assert(toml.NewEncoder(f).Encode(t))
 	f.Close()
-	return 0
 }
 
 func main() {
@@ -87,7 +84,7 @@ func main() {
 		return
 	}
 	os.Setenv("VERSION", Version)
-	basher.Application(map[string]func([]string) int{
+	basher.Application(map[string]func([]string){
 		"toml-get":        TomlGet,
 		"toml-set":        TomlSet,
 		"toml-export":     TomlExport,


### PR DESCRIPTION
Was trying to get the example working, and it was broken. Seems it was due to using the old API for `go-basher`.